### PR TITLE
install terraform & packer binaries

### DIFF
--- a/second_phase/ansible/bastion.yml
+++ b/second_phase/ansible/bastion.yml
@@ -1,3 +1,5 @@
 - hosts: 'localhost'
   roles:
     - 'bastion'
+    - 'terraform'
+    - 'packer'

--- a/second_phase/ansible/roles/packer/tasks/main.yml
+++ b/second_phase/ansible/roles/packer/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Download + unzip packer if new version is available
+  when: packer_latest != packer_installed
+  become: True
+  unarchive:
+    src: "{{ packer_release_server + packer_latest + '/packer_' + packer_latest + '_linux_amd64.zip' }}"
+    dest: "{{ packer_path | dirname }}"
+    remote_src: yes

--- a/second_phase/ansible/roles/packer/vars/main.yml
+++ b/second_phase/ansible/roles/packer/vars/main.yml
@@ -1,0 +1,6 @@
+packer_github_api: "https://api.github.com/repos/hashicorp/packer/"
+packer_release_server: "https://releases.hashicorp.com/packer/"
+packer_path: /opt/packer
+# packer has no releases on github, so use the first tag (we'll run alphas, dammit)
+packer_latest: "{{ ( lookup('url', packer_github_api + 'tags', split_lines=False) | from_json | first)['name'] | regex_replace('^v', '') }}"
+packer_installed: "{{ lookup('pipe', 'test ! -x ' + packer_path + ' || ' + packer_path + ' version 2>&1') | regex_replace('^Packer v', '') }}"

--- a/second_phase/ansible/roles/terraform/tasks/main.yml
+++ b/second_phase/ansible/roles/terraform/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Download + unzip terraform if new version is available
+  when: tf_latest != tf_installed
+  become: True
+  unarchive:
+    src: "{{ tf_release_server + tf_latest + '/terraform_' + tf_latest + '_linux_amd64.zip' }}"
+    dest: "{{ tf_path | dirname }}"
+    remote_src: yes

--- a/second_phase/ansible/roles/terraform/vars/main.yml
+++ b/second_phase/ansible/roles/terraform/vars/main.yml
@@ -1,0 +1,5 @@
+tf_github_api: "https://api.github.com/repos/hashicorp/terraform/"
+tf_release_server: "https://releases.hashicorp.com/terraform/"
+tf_path: /opt/terraform
+tf_latest: "{{ ( lookup('url', tf_github_api + 'releases/latest', split_lines=False) | from_json )['tag_name'] | regex_replace('^v', '') }}"
+tf_installed: "{{ lookup('pipe', 'test ! -x ' + tf_path + ' || ' + tf_path + ' version 2>&1') | regex_replace('^Terraform v', '') }}"


### PR DESCRIPTION
uses github api to get latest release (tag for packer which has no
releases), downloads from hashicorp release server and installs in /opt

obsoletes #2 